### PR TITLE
Universal module definition

### DIFF
--- a/js/qrcode.js
+++ b/js/qrcode.js
@@ -1632,3 +1632,13 @@ var qrcode = function() {
 
   return qrcode;
 }();
+
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+      define([], factory);
+  } else if (typeof exports === 'object') {
+      module.exports = factory();
+  }
+}(function () {
+    return qrcode;
+}));


### PR DESCRIPTION
Allow the script to be loaded in browser (global qrcode variable), in AMD or node.

Right now `require('qrcode-generator')` does nothing. This allows to use the library in more ways.
