### PR TITLE
Scalable SVGs and white background

### DIFF
--- a/js/qrcode.js
+++ b/js/qrcode.js
@@ -475,11 +475,12 @@ var qrcode = function() {
       rect = 'l' + cellSize + ',0 0,' + cellSize +
         ' -' + cellSize + ',0 0,-' + cellSize + 'z ';
 
-      qrSvg += '<svg';
+      qrSvg += '<svg version="1.1" xmlns="http://www.w3.org/2000/svg"';
       qrSvg += ' width="' + size + 'px"';
       qrSvg += ' height="' + size + 'px"';
-      qrSvg += ' xmlns="http://www.w3.org/2000/svg"';
-      qrSvg += '>';
+      qrSvg += ' viewBox="0 0 ' + size + ' ' + size + '" ';
+      qrSvg += ' preserveAspectRatio="xMinYMin meet">';
+      qrSvg += '<rect width="100%" height="100%" fill="white" cx="0" cy="0"/>';
       qrSvg += '<path d="';
 
       for (r = 0; r < _this.getModuleCount(); r += 1) {


### PR DESCRIPTION
Opening a QR Code without background in most image viewers would make them unreadable (tile background is a frequent feature in most image viewers for highlighting transparency; I blame Adobe Photoshop).
There already was a PR but I've decided to copy over my local modifications along with my scalability patch, so this whole PR makes the SVG generation more solid for your great library, Kazuhiko-san.