### PR TITLE
Add function for rendering to canvas 2D context

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -84,3 +84,4 @@ Helper functions for HTML.
 
 The word 'QR Code' is registered trademark of DENSO WAVE INCORPORATED
 <br/>http://www.denso-wave.com/qrcode/faqpatent-e.html
+#### renderTo2dContext(context, cellSize) => <code>void</code>

--- a/js/qrcode.d.ts
+++ b/js/qrcode.d.ts
@@ -31,6 +31,7 @@ interface QRCode {
   createImgTag(cellSize?: number, margin?: number) : string;
   createSvgTag(cellSize?: number, margin?: number) : string;
   createTableTag(cellSize?: number, margin?: number) : string;
+  renderTo2dContext(context: CanvasRenderingContext2D, cellSize?: number): void;
 }
 
 declare var qrcode : QRCodeFactory;

--- a/js/qrcode.js
+++ b/js/qrcode.js
@@ -546,6 +546,17 @@ var qrcode = function() {
       } );
     };
 
+    _this.renderTo2dContext = function(context, cellSize) {
+      cellSize = cellSize || 2;
+      var length = _this.getModuleCount();
+      for (var row = 0; row < length; row++) {
+        for (var col = 0; col < length; col++) {
+          context.fillStyle = _this.isDark(row, col) ? 'black' : 'white';
+          context.fillRect(row * cellSize, col * cellSize, cellSize, cellSize);
+        }
+      }
+    }
+
     return _this;
   };
 


### PR DESCRIPTION
Hey, I have added `renderTo2dContext` function which takes a `context` one would get by calling `getContext('2d')` on a `canvas` element and optional `cellSize` and renders the QR code onto the canvas.

I decided against adding `x` and `y` coordinate arguments as I expect people will, like me, want to use this to render to a `canvas` element prepared so that it is a perfect fit for the QR code. I can add it if you like.

I have also avoided updating the demo, as it didn't seem like showcasing rendering to `canvas` would add anything to it (it doesn't list API methods or anything). One thing to note, though, is that the `qrcode.js` file in the demo and the one directly in `js` **are different**. I am not sure if you are aware of this. I didn't find any way through which the file in the demo was copied over from the main file or anything like that, so I left it alone, but I can fix that for you by replacing the demo file with the main file. Let me know if you want that.
