### PR TITLE
add renderTo2dContext()"s optional position params

### DIFF
--- a/js/qrcode.d.ts
+++ b/js/qrcode.d.ts
@@ -45,7 +45,7 @@ interface QRCode {
   createDataURL(cellSize?: number, margin?: number) : string;
   createTableTag(cellSize?: number, margin?: number) : string;
   createASCII(cellSize?: number, margin?: number) : string;
-  renderTo2dContext(context: CanvasRenderingContext2D, cellSize?: number): void;
+  renderTo2dContext(context: CanvasRenderingContext2D, cellSize?: number, position?: { x: number, y: number }): void;
 }
 
 declare var qrcode : QRCodeFactory;

--- a/js/qrcode.js
+++ b/js/qrcode.js
@@ -666,16 +666,22 @@ var qrcode = function() {
       return ascii.substring(0, ascii.length-1);
     };
 
-    _this.renderTo2dContext = function(context, cellSize) {
+    _this.renderTo2dContext = function (context, cellSize, position) {
       cellSize = cellSize || 2;
+      position = position || { x: 0, y: 0 };
       var length = _this.getModuleCount();
       for (var row = 0; row < length; row++) {
         for (var col = 0; col < length; col++) {
-          context.fillStyle = _this.isDark(row, col) ? 'black' : 'white';
-          context.fillRect(row * cellSize, col * cellSize, cellSize, cellSize);
+          context.fillStyle = _this.isDark(row, col) ? "black" : "white";
+          context.fillRect(
+            row * cellSize + position.x,
+            col * cellSize + position.y,
+            cellSize,
+            cellSize
+          );
         }
       }
-    }
+    };
 
     return _this;
   };


### PR DESCRIPTION
Added a parameter for function `renderTo2dContext()` to render the qrcode to designated position in canvas context instead of the left top corner
```
renderTo2dContext(context: CanvasRenderingContext2D, cellSize?: number, position?: {x: number, y: number}): void;
```