### PR TITLE
fix #66: generateASCII with cellsize 1 and margin 0

### DIFF
--- a/js/qrcode.js
+++ b/js/qrcode.js
@@ -591,6 +591,13 @@ var qrcode = function() {
         '  ': ' '
       };
 
+      var blocksLastLineNoMargin = {
+        '██': '▀',
+        '█ ': '▀',
+        ' █': ' ',
+        '  ': ' '
+      };
+
       var ascii = '';
       for (y = 0; y < size; y += 2) {
         r1 = Math.floor((y - min) / cellSize);
@@ -610,13 +617,13 @@ var qrcode = function() {
           }
 
           // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
-          ascii += blocks[p];
+          ascii += (margin < 1 && y+1 >= max) ? blocksLastLineNoMargin[p] : blocks[p];
         }
 
         ascii += '\n';
       }
 
-      if (size % 2) {
+      if (size % 2 && margin > 0) {
         return ascii.substring(0, ascii.length - size - 1) + Array(size+1).join('▀');
       }
 

--- a/js/test/qrcode.js
+++ b/js/test/qrcode.js
@@ -56,6 +56,23 @@ describe('QRCode', function(){
 			'▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀'].join('\n');
 
 		var correctTextData2 = [
+			' ▄▄▄▄▄ █ ▄█▀▄██ ▀▄ ▄██ ▄▄▄▄▄ ',
+			' █   █ █▀ █▀▄█▀▀█▄▄ ▄█ █   █ ',
+			' █▄▄▄█ ███ ▀ █▄▀▄▄▀ ▀█ █▄▄▄█ ',
+			'▄▄▄▄▄▄▄█ ▀▄█▄▀▄▀ █▄▀▄█▄▄▄▄▄▄▄',
+			'▄█  ▀▄▄▄█▄▄█▀█▀▀▄█▀▀▀█ ▀▀▄█▄ ',
+			'▀▀▄▀▄█▄█  ▄▄█▄ ▄█  ███ ▀█▀▄▄▀',
+			' ▄▀█▄▀▄  ▄▀▄ █ ▄▀▀█▀██▀██▄▄▀▀',
+			'  █▀ ▄▄▀▀ ▀█    █▀▄ ▀█▄▀▄▄▄ ▄',
+			'▄██ ▄▄▄▄▄█   ▀▄▄ ▀▀▄▄▄█▄▄█▀ █',
+			'▄█▄██▄▄▄ █ █▄▄▀█▀███▄▀▄▄█▄ ██',
+			'█▄▄██▄▄▄ ▀▀▄█ █▀ █ ▄ ▄▄▄   ▀▀',
+			' ▄▄▄▄▄ █ █ ▀█▄█ ▀  ▄ █▄█ ▄█ ▀',
+			' █   █ █▀▄▄ ▄▀ ▀▄█ █  ▄▄   ▄ ',
+			' █▄▄▄█ █▄█▄▀█ ▀ ▀ ██  █ █▀▄▀▄',
+			'       ▀  ▀ ▀ ▀▀▀    ▀▀▀▀ ▀ ▀'].join('\n');
+
+		var correctTextData3 = [
 			'██████████████████████████████████████████████████████████████████',
 			'██████████████████████████████████████████████████████████████████',
 			'████              ██    ████  ████  ██      ████              ████',
@@ -95,6 +112,7 @@ describe('QRCode', function(){
 		qr.make();
 
 		assert.strictEqual(qr.createASCII(), correctTextData1, 'ASCII QRCode of size 1 is incorrect');
-		assert.strictEqual(qr.createASCII(2), correctTextData2, 'ASCII QRCode of size 2 is incorrect');
+		assert.strictEqual(qr.createASCII(1, 0), correctTextData2, 'ASCII QRCode of size 1 without margin is incorrect');
+		assert.strictEqual(qr.createASCII(2), correctTextData3, 'ASCII QRCode of size 2 is incorrect');
 	});
 });


### PR DESCRIPTION
Fix #66: when margins are 0 and cell size is 1, make sure all needed lines are rendered and do not add any filler line.