### PR TITLE
Avoid warning on PHP 7

### DIFF
--- a/php/qrcode.php
+++ b/php/qrcode.php
@@ -90,7 +90,7 @@ class QRCode {
         $this->qrDataList = array();
     }
 
-    function addDataImpl(&$qrData) {
+    function addDataImpl($qrData) {
         $this->qrDataList[] = $qrData;
     }
 


### PR DESCRIPTION
There is no need for the reference parameter here (its arguments are objects like “new QRNumber”), and expressions can’t be passed as references.