### PR TITLE
Compatibility with newer hhvm versions

### DIFF
--- a/hack/.gitignore
+++ b/hack/.gitignore
@@ -1,2 +1,3 @@
 vendor/**
 **/*hhast.parser-cache
+.var/

--- a/hack/.hhconfig
+++ b/hack/.hhconfig
@@ -1,3 +1,5 @@
 ignored_paths = [ "vendor/.+/tests/.+", "vendor/.+/bin/.+"]
 hackfmt.line_width = 80
 hackfmt.indent_width = 4
+allowed_decl_fixme_codes = 2053, 4047
+allowed_fixme_codes_strict = 2049, 2053, 4027, 4047, 4104, 4107, 4110, 4128, 4188, 4323

--- a/hack/composer.json
+++ b/hack/composer.json
@@ -5,8 +5,7 @@
         "hhvm": "^4.32"
     },
     "require-dev": {
-        "hhvm/hhvm-autoload": "^2.0",
-        "hhvm/hsl": "^4.36",
+        "hhvm/hhvm-autoload": "^2.0|^3.0",
         "hhvm/hhast": "^4.41"
     }
 }

--- a/hack/composer.lock
+++ b/hack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd0bff498cbe3f820db69096d0f31f29",
+    "content-hash": "4ed88c19555ce68727abcb48b3f61520",
     "packages": [],
     "packages-dev": [
         {
@@ -41,32 +41,37 @@
             "license": [
                 "MIT"
             ],
+            "support": {
+                "issues": "https://github.com/hhvm/difflib/issues",
+                "source": "https://github.com/hhvm/difflib/tree/v1.2.0"
+            },
             "time": "2019-07-22T20:15:27+00:00"
         },
         {
             "name": "facebook/hh-clilib",
-            "version": "v2.3.0",
+            "version": "v2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hh-clilib.git",
-                "reference": "10845e8780436728cdc0b9abbe20446777bdb199"
+                "reference": "a275f2fe7e5c1144c09793fcb2a8f57533f2eb68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hh-clilib/zipball/10845e8780436728cdc0b9abbe20446777bdb199",
-                "reference": "10845e8780436728cdc0b9abbe20446777bdb199",
+                "url": "https://api.github.com/repos/hhvm/hh-clilib/zipball/a275f2fe7e5c1144c09793fcb2a8f57533f2eb68",
+                "reference": "a275f2fe7e5c1144c09793fcb2a8f57533f2eb68",
                 "shasum": ""
             },
             "require": {
-                "hhvm": "^4.41",
+                "hhvm": "^4.76",
                 "hhvm/hsl": "^4.0",
-                "hhvm/hsl-experimental": "^4.50",
-                "hhvm/type-assert": "^3.2"
+                "hhvm/hsl-experimental": "^4.58.0rc1",
+                "hhvm/hsl-io": "^0.3.0",
+                "hhvm/type-assert": "^4.0"
             },
             "require-dev": {
                 "facebook/fbexpect": "^2.6.1",
-                "hhvm/hacktest": "^2.0",
-                "hhvm/hhast": "^4.0.2"
+                "hhvm/hacktest": "^2.2.0rc1",
+                "hhvm/hhvm-autoload": "^3.1.0"
             },
             "type": "library",
             "extra": {
@@ -78,41 +83,44 @@
             "license": [
                 "MIT"
             ],
-            "time": "2020-03-27T16:47:22+00:00"
+            "support": {
+                "issues": "https://github.com/hhvm/hh-clilib/issues",
+                "source": "https://github.com/hhvm/hh-clilib/tree/v2.6.0"
+            },
+            "time": "2020-12-14T21:29:15+00:00"
         },
         {
             "name": "hhvm/hhast",
-            "version": "v4.41.2",
+            "version": "v4.103.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hhast.git",
-                "reference": "218a6d8f28cff5969f976f875e75eb00bd4cdcc5"
+                "reference": "a458cfa93c6de7e0d5d79e8242f50134187b8c6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hhast/zipball/218a6d8f28cff5969f976f875e75eb00bd4cdcc5",
-                "reference": "218a6d8f28cff5969f976f875e75eb00bd4cdcc5",
+                "url": "https://api.github.com/repos/hhvm/hhast/zipball/a458cfa93c6de7e0d5d79e8242f50134187b8c6a",
+                "reference": "a458cfa93c6de7e0d5d79e8242f50134187b8c6a",
                 "shasum": ""
             },
             "require": {
                 "facebook/difflib": "^1.0.0",
-                "facebook/hh-clilib": "^2.0.0",
-                "hhvm": "^4.41",
+                "facebook/hh-clilib": "^2.5.0rc1",
+                "hhvm": "^4.103",
                 "hhvm/hhvm-autoload": "^2.0.4|^3.0",
                 "hhvm/hsl": "^4.25",
-                "hhvm/hsl-experimental": "^4.50",
-                "hhvm/type-assert": "^3.4"
+                "hhvm/hsl-experimental": "^4.58.0rc1",
+                "hhvm/hsl-io": "^0.2.0|0.3.0",
+                "hhvm/type-assert": "^3.0|^4.0"
             },
             "require-dev": {
                 "facebook/fbexpect": "^2.1.1",
                 "facebook/hack-codegen": "^4.0",
-                "hhvm/hacktest": "^2.0"
+                "hhvm/hacktest": "^2.2.0"
             },
             "bin": [
                 "bin/hhast-lint",
                 "bin/hhast-lint.hack",
-                "bin/hhast-inspect",
-                "bin/hhast-inspect.hack",
                 "bin/hhast-migrate",
                 "bin/hhast-migrate.hack"
             ],
@@ -127,25 +135,29 @@
                 "MIT"
             ],
             "description": "A mutable AST library for Hack with linting and code migrations",
-            "time": "2020-04-08T15:46:11+00:00"
+            "support": {
+                "issues": "https://github.com/hhvm/hhast/issues",
+                "source": "https://github.com/hhvm/hhast/tree/v4.103.1"
+            },
+            "time": "2021-03-31T22:58:13+00:00"
         },
         {
             "name": "hhvm/hhvm-autoload",
-            "version": "v2.0.13",
+            "version": "v3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hhvm-autoload.git",
-                "reference": "816e33cd940844898b04e1c2101d2cfeb3879272"
+                "reference": "2c92708ac3c7ba9bb6d93c4bf7d97ea422ae41a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hhvm-autoload/zipball/816e33cd940844898b04e1c2101d2cfeb3879272",
-                "reference": "816e33cd940844898b04e1c2101d2cfeb3879272",
+                "url": "https://api.github.com/repos/hhvm/hhvm-autoload/zipball/2c92708ac3c7ba9bb6d93c4bf7d97ea422ae41a2",
+                "reference": "2c92708ac3c7ba9bb6d93c4bf7d97ea422ae41a2",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
-                "hhvm": "^4.25",
+                "composer-plugin-api": "^1.0|^2.0",
+                "hhvm": "^4.67",
                 "hhvm/hsl": "^4.0"
             },
             "replace": {
@@ -165,7 +177,8 @@
                     "Facebook\\AutoloadMap\\ComposerPlugin"
                 ],
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev",
+                    "dev-CI_current_pull_request": "3.x-dev"
                 }
             },
             "autoload": {
@@ -174,35 +187,43 @@
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "time": "2020-02-07T20:45:31+00:00"
+            "license": [
+                "MIT"
+            ],
+            "support": {
+                "issues": "https://github.com/hhvm/hhvm-autoload/issues",
+                "source": "https://github.com/hhvm/hhvm-autoload/tree/v3.2.0"
+            },
+            "time": "2020-12-11T21:40:51+00:00"
         },
         {
             "name": "hhvm/hsl",
-            "version": "v4.40.0",
+            "version": "v4.108.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hsl.git",
-                "reference": "b14a430062ad95c378765899f955457f3454f2f9"
+                "reference": "3b4375e6adf63ac9171721b031b662dd3524c5bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hsl/zipball/b14a430062ad95c378765899f955457f3454f2f9",
-                "reference": "b14a430062ad95c378765899f955457f3454f2f9",
+                "url": "https://api.github.com/repos/hhvm/hsl/zipball/3b4375e6adf63ac9171721b031b662dd3524c5bb",
+                "reference": "3b4375e6adf63ac9171721b031b662dd3524c5bb",
                 "shasum": ""
             },
             "require": {
-                "hhvm": "^4.25"
+                "hhvm": "^4.108"
             },
             "require-dev": {
                 "facebook/fbexpect": "^2.5.1",
                 "hhvm/hacktest": "^1.0|^2.0",
-                "hhvm/hhvm-autoload": "^2.0",
-                "hhvm/hsl-experimental": "dev-master"
+                "hhvm/hhvm-autoload": "^2.0|^3.0",
+                "hhvm/hsl-experimental": "^4.37|dev-master"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-master": "4.x-dev",
+                    "dev-CI_current_pull_request": "4.x-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -210,25 +231,32 @@
                 "MIT"
             ],
             "description": "The Hack Standard Library",
-            "time": "2020-01-08T23:12:08+00:00"
+            "support": {
+                "issues": "https://github.com/hhvm/hsl/issues",
+                "source": "https://github.com/hhvm/hsl/tree/v4.108.1"
+            },
+            "time": "2021-05-04T14:32:06+00:00"
         },
         {
             "name": "hhvm/hsl-experimental",
-            "version": "v4.50.0",
+            "version": "v4.108.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hsl-experimental.git",
-                "reference": "cf23c87c2b16cbffe067974b45beb5b512edd4eb"
+                "reference": "c145eda4344a3668119fde743e9d224bae7efe98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hsl-experimental/zipball/cf23c87c2b16cbffe067974b45beb5b512edd4eb",
-                "reference": "cf23c87c2b16cbffe067974b45beb5b512edd4eb",
+                "url": "https://api.github.com/repos/hhvm/hsl-experimental/zipball/c145eda4344a3668119fde743e9d224bae7efe98",
+                "reference": "c145eda4344a3668119fde743e9d224bae7efe98",
                 "shasum": ""
             },
             "require": {
-                "hhvm": "^4.41",
+                "hhvm": "^4.108",
                 "hhvm/hsl": "^4.15"
+            },
+            "provide": {
+                "hhvm/hsl-io": "0.3.0"
             },
             "require-dev": {
                 "facebook/fbexpect": "^2.7.0",
@@ -246,36 +274,40 @@
                 "MIT"
             ],
             "description": "The Hack Standard Library - Experimental Additions",
-            "time": "2020-03-27T15:38:24+00:00"
+            "support": {
+                "issues": "https://github.com/hhvm/hsl-experimental/issues",
+                "source": "https://github.com/hhvm/hsl-experimental/tree/v4.108.0"
+            },
+            "time": "2021-05-04T18:41:22+00:00"
         },
         {
             "name": "hhvm/type-assert",
-            "version": "v3.7.3",
+            "version": "v4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/type-assert.git",
-                "reference": "e076c42ed718929dbea96c0b354ebe96cccc2335"
+                "reference": "c5028eb6fc68259f90e46d80e1b78dee905c765f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/type-assert/zipball/e076c42ed718929dbea96c0b354ebe96cccc2335",
-                "reference": "e076c42ed718929dbea96c0b354ebe96cccc2335",
+                "url": "https://api.github.com/repos/hhvm/type-assert/zipball/c5028eb6fc68259f90e46d80e1b78dee905c765f",
+                "reference": "c5028eb6fc68259f90e46d80e1b78dee905c765f",
                 "shasum": ""
             },
             "require": {
-                "hhvm": "^4.30",
+                "hhvm": "^4.80",
                 "hhvm/hsl": "^4.0"
             },
             "require-dev": {
                 "facebook/fbexpect": "^2.0.0",
                 "hhvm/hacktest": "^2.0",
                 "hhvm/hhast": "^4.0",
-                "hhvm/hhvm-autoload": "^2.0"
+                "hhvm/hhvm-autoload": "^2.0|^3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.x-dev"
+                    "dev-master": "4.x-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -287,7 +319,11 @@
                 "TypeAssert",
                 "hack"
             ],
-            "time": "2020-01-13T21:48:58+00:00"
+            "support": {
+                "issues": "https://github.com/hhvm/type-assert/issues",
+                "source": "https://github.com/hhvm/type-assert/tree/v4.2.0"
+            },
+            "time": "2020-12-11T21:45:47+00:00"
         }
     ],
     "aliases": [],
@@ -298,5 +334,6 @@
     "platform": {
         "hhvm": "^4.32"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }

--- a/hack/samples/sample_custom.php
+++ b/hack/samples/sample_custom.php
@@ -2,10 +2,10 @@
 
 use namespace Kazuhikoarase\QrcodeGenerator;
 
-require_once(__DIR__.'/../vendor/hh_autoload.php');
-
 <<__EntryPoint>>
 function sample_custom(): noreturn {
+    require_once __DIR__.'/../vendor/autoload.hack';
+    \Facebook\AutoloadMap\initialize();
     $qr = QrcodeGenerator\QRCode::getMinimumQRCode(
         "日本語のQR 1234:! 漢字",
         QrcodeGenerator\ErrorCorrectionPercentage::SEVEN,

--- a/hack/samples/sample_html.php
+++ b/hack/samples/sample_html.php
@@ -2,10 +2,10 @@
 
 use namespace Kazuhikoarase\QrcodeGenerator;
 
-require_once(__DIR__.'/../vendor/hh_autoload.php');
-
 <<__EntryPoint>>
 function sample_html(): noreturn {
+    require_once __DIR__.'/../vendor/autoload.hack';
+    \Facebook\AutoloadMap\initialize();
     //---------------------------------------------------------
 
     print('<meta charset="UTF-8">');

--- a/hack/samples/sample_image.php
+++ b/hack/samples/sample_image.php
@@ -2,10 +2,11 @@
 
 use namespace Kazuhikoarase\QrcodeGenerator;
 
-require_once(__DIR__.'/../vendor/hh_autoload.php');
 
 <<__EntryPoint>>
 function sample_image(): noreturn {
+    require_once __DIR__.'/../vendor/autoload.hack';
+    \Facebook\AutoloadMap\initialize();
     $qr = QrcodeGenerator\QRCode::getMinimumQRCode(
         "日本語のQR 1234:! 漢字",
         QrcodeGenerator\ErrorCorrectionPercentage::SEVEN,

--- a/hack/src/qrcode.hack
+++ b/hack/src/qrcode.hack
@@ -139,7 +139,6 @@ final class QRCode {
         $pattern = MaskPattern::P000;
 
         foreach (MaskPattern::getValues() as $i) {
-
             $this->makeImpl(true, $i);
 
             $lostPoint = QRUtil::getLostPoint($this);
@@ -197,17 +196,13 @@ final class QRCode {
         $byteIndex = 0;
 
         for ($col = $this->moduleCount - 1; $col > 0; $col -= 2) {
-
             if ($col === 6) {
                 $col--;
             }
 
             while (true) {
-
                 for ($c = 0; $c < 2; $c++) {
-
                     if ($this->modules[$row][$col - $c] === null) {
-
                         $dark = false;
 
                         if ($byteIndex < C\count($data)) {
@@ -246,9 +241,7 @@ final class QRCode {
         $pos = QRUtil::getPatternPosition($this->typeNumber);
 
         for ($i = 0; $i < C\count($pos); $i++) {
-
             for ($j = 0; $j < C\count($pos); $j++) {
-
                 $row = $pos[$i];
                 $col = $pos[$j];
 
@@ -257,7 +250,6 @@ final class QRCode {
                 }
 
                 for ($r = -2; $r <= 2; $r++) {
-
                     for ($c = -2; $c <= 2; $c++) {
                         $this->modules[$row + $r][$col + $c] = $r === -2 ||
                             $r === 2 ||
@@ -273,9 +265,7 @@ final class QRCode {
     public function setupPositionProbePattern(int $row, int $col): void {
 
         for ($r = -1; $r <= 7; $r++) {
-
             for ($c = -1; $c <= 7; $c++) {
-
                 if (
                     $row + $r <= -1 ||
                     $this->moduleCount <= $row + $r ||
@@ -297,7 +287,6 @@ final class QRCode {
     public function setupTimingPattern(): void {
 
         for ($i = 8; $i < $this->moduleCount - 8; $i++) {
-
             if (
                 $this->modules[$i][6] !== null || $this->modules[6][$i] !== null
             ) {
@@ -334,7 +323,6 @@ final class QRCode {
         $bits = QRUtil::getBCHTypeInfo($data);
 
         for ($i = 0; $i < 15; $i++) {
-
             $mod = (!$test && (($bits >> $i) & 1) === 1);
 
             if ($i < 6) {
@@ -401,7 +389,6 @@ final class QRCode {
 
         // padding
         while (true) {
-
             if ($buffer->getLengthInBits() >= $totalDataCount * 8) {
                 break;
             }
@@ -431,7 +418,6 @@ final class QRCode {
 
         $rsBlockCount = C\count($rsBlocks);
         for ($r = 0; $r < $rsBlockCount; $r++) {
-
             $dcCount = $rsBlocks[$r]->getDataCount();
             $ecCount = $rsBlocks[$r]->getTotalCount() - $dcCount;
 
@@ -580,7 +566,6 @@ final class QRCode {
         for ($r = 0; $r < $this->getModuleCount(); $r++) {
             for ($c = 0; $c < $this->getModuleCount(); $c++) {
                 if ($this->isDark($r, $c)) {
-
                     // update $black to $fgc
                     \imagefilledrectangle(
                         $image,
@@ -605,7 +590,6 @@ final class QRCode {
         QRUtil::printString("<table style='".$style."'>");
 
         for ($r = 0; $r < $this->getModuleCount(); $r++) {
-
             QRUtil::printString("<tr style='".$style."'>");
 
             for ($c = 0; $c < $this->getModuleCount(); $c++) {
@@ -859,24 +843,19 @@ final abstract class QRUtil {
 
         $lostPoint = 0;
 
-
         // LEVEL1
 
         for ($row = 0; $row < $moduleCount; $row++) {
-
             for ($col = 0; $col < $moduleCount; $col++) {
-
                 $sameCount = 0;
                 $dark = $qrCode->isDark($row, $col);
 
                 for ($r = -1; $r <= 1; $r++) {
-
                     if ($row + $r < 0 || $moduleCount <= $row + $r) {
                         continue;
                     }
 
                     for ($c = -1; $c <= 1; $c++) {
-
                         if (
                             ($col + $c < 0 || $moduleCount <= $col + $c) ||
                             ($r === 0 && $c === 0)
@@ -1027,7 +1006,6 @@ final abstract class QRUtil {
         $i = 0;
 
         while ($i + 1 < Str\length($data)) {
-
             $c = ((0xff & \ord($data[$i])) << 8) | (0xff & \ord($data[$i + 1]));
 
             if (
@@ -1368,7 +1346,6 @@ final class QRRSBlock {
         $list = vec[];
 
         for ($i = 0; $i < $length; $i++) {
-
             $count = $rsBlock[$i * 3 + 0];
             $totalCount = $rsBlock[$i * 3 + 1];
             $dataCount = $rsBlock[$i * 3 + 2];
@@ -1423,7 +1400,6 @@ final class QRNumber extends QRData {
         }
 
         if ($i < Str\length($data)) {
-
             if (Str\length($data) - $i === 1) {
                 $num = QRNumber::parseInt(Str\slice($data, $i, $i + 1));
                 $buffer->put($num, 4);
@@ -1471,7 +1447,6 @@ final class QRKanji extends QRData {
         $i = 0;
 
         while ($i + 1 < Str\length($data)) {
-
             $c = ((0xff & \ord($data[$i])) << 8) | (0xff & \ord($data[$i + 1]));
 
             if (0x8140 <= $c && $c <= 0x9FFC) {
@@ -1619,7 +1594,6 @@ abstract class QRData {
     public function getLengthInBits(int $type): int {
 
         if (1 <= $type && $type < 10) {
-
             // 1 - 9
 
             switch ($this->mode) {
@@ -1634,7 +1608,6 @@ abstract class QRData {
             }
 
         } else if ($type < 27) {
-
             // 10 - 26
 
             switch ($this->mode) {
@@ -1649,7 +1622,6 @@ abstract class QRData {
             }
 
         } else if ($type < 41) {
-
             // 27 - 40
 
             switch ($this->mode) {
@@ -1878,7 +1850,6 @@ function error_correction_percentage_as_int(
 ): int {
     return $percentage as int;
 }
-
 
 //---------------------------------------------------------------
 // QRBitBuffer

--- a/hack/src/qrcode.hack
+++ b/hack/src/qrcode.hack
@@ -206,9 +206,8 @@ final class QRCode {
                         $dark = false;
 
                         if ($byteIndex < C\count($data)) {
-                            $dark = (
-                                (($data[$byteIndex] >> $bitIndex) & 1) === 1
-                            );
+                            $dark = (($data[$byteIndex] >> $bitIndex) & 1) ===
+                                1;
                         }
 
                         if (QRUtil::getMask($maskPattern, $row, $col - $c)) {
@@ -293,8 +292,8 @@ final class QRCode {
                 continue;
             }
 
-            $this->modules[$i][6] = ($i % 2 === 0);
-            $this->modules[6][$i] = ($i % 2 === 0);
+            $this->modules[$i][6] = $i % 2 === 0;
+            $this->modules[6][$i] = $i % 2 === 0;
         }
     }
 
@@ -303,7 +302,7 @@ final class QRCode {
         $bits = QRUtil::getBCHTypeNumber($this->typeNumber);
 
         for ($i = 0; $i < 18; $i++) {
-            $mod = (!$test && (($bits >> $i) & 1) === 1);
+            $mod = !$test && (($bits >> $i) & 1) === 1;
             $this->modules[(int)Math\floor($i / 3)][
                 $i % 3 + $this->moduleCount - 8 - 3
             ] = $mod;
@@ -323,7 +322,7 @@ final class QRCode {
         $bits = QRUtil::getBCHTypeInfo($data);
 
         for ($i = 0; $i < 15; $i++) {
-            $mod = (!$test && (($bits >> $i) & 1) === 1);
+            $mod = !$test && (($bits >> $i) & 1) === 1;
 
             if ($i < 6) {
                 $this->modules[$i][8] = $mod;
@@ -441,9 +440,7 @@ final class QRCode {
             $ecDataCount = C\count($ecdata[$r]);
             for ($i = 0; $i < $ecDataCount; $i++) {
                 $modIndex = $i + $modPoly->getLength() - C\count($ecdata[$r]);
-                $ecdata[$r][$i] = ($modIndex >= 0)
-                    ? $modPoly->get($modIndex)
-                    : 0;
+                $ecdata[$r][$i] = $modIndex >= 0 ? $modPoly->get($modIndex) : 0;
             }
         }
 
@@ -870,7 +867,7 @@ final abstract class QRUtil {
                 }
 
                 if ($sameCount > 5) {
-                    $lostPoint += (3 + $sameCount - 5);
+                    $lostPoint += 3 + $sameCount - 5;
                 }
             }
         }
@@ -1032,10 +1029,8 @@ final abstract class QRUtil {
     public static function getBCHTypeInfo(int $data): int {
         $d = $data << 10;
         while (QRUtil::getBCHDigit($d) - QRUtil::getBCHDigit(QR_G15) >= 0) {
-            $d ^= (
-                QR_G15 <<
-                (QRUtil::getBCHDigit($d) - QRUtil::getBCHDigit(QR_G15))
-            );
+            $d ^= QR_G15 <<
+                (QRUtil::getBCHDigit($d) - QRUtil::getBCHDigit(QR_G15));
         }
         return (($data << 10) | $d) ^ QR_G15_MASK;
     }
@@ -1043,10 +1038,8 @@ final abstract class QRUtil {
     public static function getBCHTypeNumber(int $data): int {
         $d = $data << 12;
         while (QRUtil::getBCHDigit($d) - QRUtil::getBCHDigit(QR_G18) >= 0) {
-            $d ^= (
-                QR_G18 <<
-                (QRUtil::getBCHDigit($d) - QRUtil::getBCHDigit(QR_G18))
-            );
+            $d ^= QR_G18 <<
+                (QRUtil::getBCHDigit($d) - QRUtil::getBCHDigit(QR_G18));
         }
         return ($data << 12) | $d;
     }


### PR DESCRIPTION
This PR makes this library compatible with newer runtime versions.
It allows modern versions of the autoloader to be installed without conflict.
It updates broken require_once statements.
It also lints with new linters.