### PR TITLE
Change shape-rendering of SVG to avoid smooth borders

### DIFF
--- a/php/qrcode.php
+++ b/php/qrcode.php
@@ -551,7 +551,7 @@ class QRCode {
 
         print("</table>");
     }
-    
+
     public function printSVG($size = 2)
     {
         $width = $this->getModuleCount() * $size;
@@ -561,7 +561,7 @@ class QRCode {
         for ($r = 0; $r < $this->getModuleCount(); $r++) {
             for ($c = 0; $c < $this->getModuleCount(); $c++) {
                 $color = $this->isDark($r, $c) ? "#000000" : "#ffffff";
-                print('<rect x="' . ($c * $size) . '" y="' . ($r * $size) . '" width="' . $size . '" height="' . $size . '" fill="' . $color . '"/>');
+                print('<rect x="' . ($c * $size) . '" y="' . ($r * $size) . '" width="' . $size . '" height="' . $size . '" fill="' . $color . '"stroke="'.$color.'" stroke-width="0.5"/>');
             }
         }
 

--- a/php/qrcode.php
+++ b/php/qrcode.php
@@ -561,7 +561,7 @@ class QRCode {
         for ($r = 0; $r < $this->getModuleCount(); $r++) {
             for ($c = 0; $c < $this->getModuleCount(); $c++) {
                 $color = $this->isDark($r, $c) ? "#000000" : "#ffffff";
-                print('<rect x="' . ($c * $size) . '" y="' . ($r * $size) . '" width="' . $size . '" height="' . $size . '" fill="' . $color . '"stroke="'.$color.'" stroke-width="0.5"/>');
+                print('<rect x="' . ($c * $size) . '" y="' . ($r * $size) . '" width="' . $size . '" height="' . $size . '" fill="' . $color . '" shape-rendering="crispEdges"/>');
             }
         }
 


### PR DESCRIPTION
Currently, when a qr code is exported using `printSVG` function, you can see lines/gaps between the rectangles (depending on the chosen size).

Adding `shape-rendering="crispEdges"` to the SVG rectangles eliminates these lines.
![qrcode-lines](https://user-images.githubusercontent.com/1385443/145478801-154dea56-0c97-4ce3-94bb-36e0116559c4.gif)

