### PR TITLE
Fixing a few PHP warnings

### DIFF
--- a/php/qrcode.php
+++ b/php/qrcode.php
@@ -554,6 +554,7 @@ class QRCode {
 
     public function printSVG($size = 2)
     {
+        $size = (int) $size;
         $width = $this->getModuleCount() * $size;
         $height = $width;
         print('<svg width="' . $width . '" height="' . $height . '" viewBox="0 0 ' . $width . ' ' . $height . '" xmlns="http://www.w3.org/2000/svg">');

--- a/php/qrcode.php
+++ b/php/qrcode.php
@@ -64,24 +64,27 @@ class QRCode {
         }
 
         switch($mode) {
-
-        case QR_MODE_NUMBER :
-            $this->addDataImpl(new QRNumber($data) );
+          case QR_MODE_NUMBER:
+            $d = new QRNumber($data);
+            $this->addDataImpl($d);
             break;
 
-        case QR_MODE_ALPHA_NUM :
-            $this->addDataImpl(new QRAlphaNum($data) );
+          case QR_MODE_ALPHA_NUM:
+            $d = new QRAlphaNum($data);
+            $this->addDataImpl($d);
             break;
 
-        case QR_MODE_8BIT_BYTE :
-            $this->addDataImpl(new QR8BitByte($data) );
+          case QR_MODE_8BIT_BYTE:
+            $d = new QR8BitByte($data);
+            $this->addDataImpl($d);
             break;
 
-        case QR_MODE_KANJI :
-            $this->addDataImpl(new QRKanji($data) );
+          case QR_MODE_KANJI:
+            $d = new QRKanji($data);
+            $this->addDataImpl($d);
             break;
 
-        default :
+          default:
             trigger_error("mode:$mode", E_USER_ERROR);
         }
     }


### PR DESCRIPTION
This PR fix the warning received when the code (between lines 66 and 89) calls `new` inside  `addDataImpl()`. 
Example:

```php
    $this->addDataImpl(new QRNumber($data));
```

Also fixes the `PHP Notice:  A non well formed numeric value encountered...` received when the code encounters a string where a numeric type is expected.