### PR TITLE
Generate SVG using less characters to make the file smaller.

### DIFF
--- a/js/qrcode.js
+++ b/js/qrcode.js
@@ -521,8 +521,7 @@ var qrcode = function() {
       var size = _this.getModuleCount() * cellSize + margin * 2;
       var c, mc, r, mr, qrSvg='', rect;
 
-      rect = 'l' + cellSize + ',0 0,' + cellSize +
-        ' -' + cellSize + ',0 0,-' + cellSize + 'z ';
+      rect = 'h' + cellSize + 'v' + cellSize + 'h-' + cellSize + 'z';
 
       qrSvg += '<svg version="1.1" xmlns="http://www.w3.org/2000/svg"';
       qrSvg += !opts.scalable ? ' width="' + size + 'px" height="' + size + 'px"' : '';


### PR DESCRIPTION
My test output of "https://github.com/kazuhikoarase/qrcode-generator" content went from ~14.5 kB to 8 kB :). It's now smaller than the PNG file generated from that SVG.