### PR TITLE
Add crispEdges option for SVG output in JavaScript

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -90,6 +90,7 @@ Helper functions for HTML.
 | opts.cellSize | <code>number</code>  | default: 2            |
 | opts.margin   | <code>number</code>  | default: cellSize * 4 |
 | opts.scalable | <code>boolean</code> | default: false        |
+| opts.crispEdges | <code>boolean</code> \| <code>'auto'</code> | default: auto; applies <code>crispEdges</code> automatically for whole-number <code>cellSize</code> values |
 
 #### renderTo2dContext(context, cellSize) => <code>void</code>
 

--- a/js/dist/qrcode.d.ts
+++ b/js/dist/qrcode.d.ts
@@ -43,7 +43,7 @@ interface QRCode {
   createImgTag(cellSize?: number, margin?: number) : string;
   createSvgTag(cellSize?: number, margin?: number) : string;
   createSvgTag(opts? : { cellSize?: number, margin?: number,
-      scalable?: boolean }) : string;
+      scalable?: boolean, crispEdges?: boolean | 'auto' }) : string;
   createDataURL(cellSize?: number, margin?: number) : string;
   createTableTag(cellSize?: number, margin?: number) : string;
   createASCII(cellSize?: number, margin?: number) : string;

--- a/js/dist/qrcode.js
+++ b/js/dist/qrcode.js
@@ -507,6 +507,7 @@ var qrcode = function() {
 
       cellSize = cellSize || 2;
       margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+      var crispEdges = typeof opts.crispEdges == 'undefined' ? 'auto' : opts.crispEdges;
 
       // Compose alt property surrogate
       alt = (typeof alt === 'string') ? {text: alt} : alt || {};
@@ -528,7 +529,9 @@ var qrcode = function() {
       qrSvg += !opts.scalable ? ' width="' + size + 'px" height="' + size + 'px"' : '';
       qrSvg += ' viewBox="0 0 ' + size + ' ' + size + '" ';
       qrSvg += ' preserveAspectRatio="xMinYMin meet"';
-      qrSvg += Math.abs(size - Math.round(size)) < 0.001 ? ' shape-rendering="crispEdges"' : '';
+      qrSvg += crispEdges === true ||
+        (crispEdges === 'auto' && Math.abs(cellSize - Math.round(cellSize)) < 0.001) ?
+        ' shape-rendering="crispEdges"' : '';
       qrSvg += (title.text || alt.text) ? ' role="img" aria-labelledby="' +
           escapeXml([title.id, alt.id].join(' ').trim() ) + '"' : '';
       qrSvg += '>';

--- a/js/dist/qrcode.js
+++ b/js/dist/qrcode.js
@@ -528,6 +528,7 @@ var qrcode = function() {
       qrSvg += !opts.scalable ? ' width="' + size + 'px" height="' + size + 'px"' : '';
       qrSvg += ' viewBox="0 0 ' + size + ' ' + size + '" ';
       qrSvg += ' preserveAspectRatio="xMinYMin meet"';
+      qrSvg += Math.abs(size - Math.round(size)) < 0.001 ? ' shape-rendering="crispEdges"' : '';
       qrSvg += (title.text || alt.text) ? ' role="img" aria-labelledby="' +
           escapeXml([title.id, alt.id].join(' ').trim() ) + '"' : '';
       qrSvg += '>';

--- a/js/dist/qrcode.mjs
+++ b/js/dist/qrcode.mjs
@@ -526,6 +526,7 @@ export const qrcode = function(typeNumber, errorCorrectionLevel) {
     qrSvg += !opts.scalable ? ' width="' + size + 'px" height="' + size + 'px"' : '';
     qrSvg += ' viewBox="0 0 ' + size + ' ' + size + '" ';
     qrSvg += ' preserveAspectRatio="xMinYMin meet"';
+    qrSvg += Math.abs(size - Math.round(size)) < 0.001 ? ' shape-rendering="crispEdges"' : '';
     qrSvg += (title.text || alt.text) ? ' role="img" aria-labelledby="' +
         escapeXml([title.id, alt.id].join(' ').trim() ) + '"' : '';
     qrSvg += '>';

--- a/js/dist/qrcode.mjs
+++ b/js/dist/qrcode.mjs
@@ -505,6 +505,7 @@ export const qrcode = function(typeNumber, errorCorrectionLevel) {
 
     cellSize = cellSize || 2;
     margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+    const crispEdges = typeof opts.crispEdges == 'undefined' ? 'auto' : opts.crispEdges;
 
     // Compose alt property surrogate
     alt = (typeof alt === 'string') ? {text: alt} : alt || {};
@@ -526,7 +527,9 @@ export const qrcode = function(typeNumber, errorCorrectionLevel) {
     qrSvg += !opts.scalable ? ' width="' + size + 'px" height="' + size + 'px"' : '';
     qrSvg += ' viewBox="0 0 ' + size + ' ' + size + '" ';
     qrSvg += ' preserveAspectRatio="xMinYMin meet"';
-    qrSvg += Math.abs(size - Math.round(size)) < 0.001 ? ' shape-rendering="crispEdges"' : '';
+    qrSvg += crispEdges === true ||
+      (crispEdges === 'auto' && Math.abs(cellSize - Math.round(cellSize)) < 0.001) ?
+      ' shape-rendering="crispEdges"' : '';
     qrSvg += (title.text || alt.text) ? ' role="img" aria-labelledby="' +
         escapeXml([title.id, alt.id].join(' ').trim() ) + '"' : '';
     qrSvg += '>';

--- a/js/experiment/vt/src/main/qrcode.ts
+++ b/js/experiment/vt/src/main/qrcode.ts
@@ -516,6 +516,7 @@ const qrcode : QRCodeFactory = function(typeNumber : number, errorCorrectionLeve
 
     cellSize = cellSize || 2;
     margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+    const crispEdges = typeof opts.crispEdges == 'undefined' ? 'auto' : opts.crispEdges;
 
     // Compose alt property surrogate
     alt = (typeof alt === 'string') ? {text: alt} : alt || {};
@@ -537,6 +538,9 @@ const qrcode : QRCodeFactory = function(typeNumber : number, errorCorrectionLeve
     qrSvg += !opts.scalable ? ' width="' + size + 'px" height="' + size + 'px"' : '';
     qrSvg += ' viewBox="0 0 ' + size + ' ' + size + '" ';
     qrSvg += ' preserveAspectRatio="xMinYMin meet"';
+    qrSvg += crispEdges === true ||
+      (crispEdges === 'auto' && Math.abs(cellSize - Math.round(cellSize)) < 0.001) ?
+      ' shape-rendering="crispEdges"' : '';
     qrSvg += (title.text || alt.text) ? ' role="img" aria-labelledby="' +
         escapeXml([title.id, alt.id].join(' ').trim() ) + '"' : '';
     qrSvg += '>';

--- a/js/experiment/vt/src/main/types.ts
+++ b/js/experiment/vt/src/main/types.ts
@@ -49,6 +49,7 @@ export type QRSvgTagOpts = {
   cellSize?: number,
   margin?: number,
   scalable?: boolean,
+  crispEdges?: boolean | 'auto',
   alt?: any,
   title?: any
 };

--- a/js/experiment/vt/src/test/qrcode-test-impl.js
+++ b/js/experiment/vt/src/test/qrcode-test-impl.js
@@ -272,6 +272,22 @@ export const misc = function(qrcode) {
       expect(!!qr.createSvgTag({}) ).to.be.true;
     });
 
+    it('svg tag auto crispEdges for whole-number cell size', function(){
+      const qr = qrcode(1, 'H');
+      qr.addData('{SVG}');
+      qr.make();
+      expect(qr.createSvgTag({cellSize : 2}) ).to.contain(' shape-rendering="crispEdges"');
+      expect(qr.createSvgTag({cellSize : 2.5}) ).not.to.contain(' shape-rendering="crispEdges"');
+    });
+
+    it('svg tag can force crispEdges on and off', function(){
+      const qr = qrcode(1, 'H');
+      qr.addData('{SVG}');
+      qr.make();
+      expect(qr.createSvgTag({cellSize : 2.5, crispEdges : true}) ).to.contain(' shape-rendering="crispEdges"');
+      expect(qr.createSvgTag({cellSize : 2, crispEdges : false}) ).not.to.contain(' shape-rendering="crispEdges"');
+    });
+
     it('svg tag by object (for coverage)', function(){
 
       let count = 0;

--- a/js/test/qrcode-test-impl.js
+++ b/js/test/qrcode-test-impl.js
@@ -272,6 +272,22 @@ export const misc = function(qrcode) {
       expect(!!qr.createSvgTag({}) ).to.be.true;
     });
 
+    it('svg tag auto crispEdges for whole-number cell size', function(){
+      const qr = qrcode(1, 'H');
+      qr.addData('{SVG}');
+      qr.make();
+      expect(qr.createSvgTag({cellSize : 2}) ).to.contain(' shape-rendering="crispEdges"');
+      expect(qr.createSvgTag({cellSize : 2.5}) ).not.to.contain(' shape-rendering="crispEdges"');
+    });
+
+    it('svg tag can force crispEdges on and off', function(){
+      const qr = qrcode(1, 'H');
+      qr.addData('{SVG}');
+      qr.make();
+      expect(qr.createSvgTag({cellSize : 2.5, crispEdges : true}) ).to.contain(' shape-rendering="crispEdges"');
+      expect(qr.createSvgTag({cellSize : 2, crispEdges : false}) ).not.to.contain(' shape-rendering="crispEdges"');
+    });
+
     it('svg tag by object (for coverage)', function(){
 
       let count = 0;


### PR DESCRIPTION
This PR adds a `crispEdges` option to `createSvgTag()` in the JavaScript implementation.

The new option supports three modes:
- `'auto'` (default): adds `shape-rendering="crispEdges"` only for whole-number `cellSize` values
- `true`: always adds `shape-rendering="crispEdges"`
- `false`: never adds `shape-rendering="crispEdges"`

This fixes the rendering issue described in the PHP [PR #104](https://github.com/kazuhikoarase/qrcode-generator/pull/104), while implementing the solution for the JavaScript version.

The default `auto` behavior keeps sharp rendering where it makes sense and avoids unwanted artifacts for fractional sizes:
- for whole-number cell sizes, cell boundaries align with the pixel grid, so `crispEdges` does not introduce geometric distortion
- for fractional cell sizes, forcing `crispEdges` can shift cell boundaries to the pixel grid and distort the geometry
- in practice, fractional cell sizes are usually not a meaningful target for QR modules anyway

Changes:
- add `crispEdges` option to `createSvgTag(opts)`
- update JavaScript distribution files
- update TypeScript declarations
- update README
- add test coverage for `auto`, forced enable, and forced disable